### PR TITLE
packages/.travis_do.sh: Fix Signed-off-by Name

### DIFF
--- a/.travis_do.sh
+++ b/.travis_do.sh
@@ -129,7 +129,7 @@ test_commits() {
 		fi
 
 		body="$(git show -s --format=%b $commit)"
-		sob="$(git show -s --format='Signed-off-by: %aN <%aE>' $commit)"
+		sob="$(git show -s --format='Signed-off-by: %cN <%aE>' $commit)"
 		if echo "$body" | grep -qF "$sob"; then
 			echo_green "Signed-off-by match author"
 		else


### PR DESCRIPTION
Signed-off-by format of %aN may get only a first name.
Changing the format to %cN gets the full name.

Signed-off-by: Bob Meizlik <bobmseagithub@squakmt.com>